### PR TITLE
Possible flag-based interface to reduce duplication

### DIFF
--- a/src/PseudoPotentialIO.jl
+++ b/src/PseudoPotentialIO.jl
@@ -13,7 +13,7 @@ using PrettyTables
 
 using PeriodicTable: PeriodicTable
 import Base.Broadcast.broadcastable
-import Bessels: gamma
+import Bessels: gamma, sphericalbesselj
 import SpecialFunctions: erf
 
 ## DocStringExtensions Templates
@@ -44,8 +44,8 @@ export relativistic_treatment
 export has_core_density
 export valence_charge
 export max_angular_momentum
-export n_projector_radials
-export n_chi_function_radials
+export n_beta_projector_radials
+export n_chi_projector_radials
 include("file/file.jl")
 
 export UpfFile
@@ -60,46 +60,43 @@ export HghFile
 include("file/hgh.jl")
 
 ## Pseudopotential datastructures and interface
+export AbstractPsPQuantity
+export PsPChargeDensity
+export ValenceChargeDensity
+export CoreChargeDensity
+export PsPProjector
+export BetaProjector
+export ChiProjector
+export PsPCoupling
+export BetaCoupling
+export PsPPotential
+export LocalPotential
+export AugmentationFunction
+export EvaluationSpace
+export RealSpace
+export FourierSpace
+include("psp/quantities.jl")
+
 export AbstractPsP
 export identifier
 export element
 export max_angular_momentum
-export n_projector_radials
-export n_projector_angulars
-export n_chi_function_radials
-export n_chi_function_angulars
+export n_radials
+export n_angulars
 export valence_charge
 export atomic_charge
 export is_norm_conserving
 export is_ultrasoft
 export is_paw
 export has_spin_orbit
-export has_core_density
-export has_valence_density
-export has_chi_functions
-export projector_coupling
-export local_potential_cutoff_radius
-export projector_cutoff_radius
-export chi_function_cutoff_radius
-export valence_charge_density_cutoff_radius
-export core_charge_density_cutoff_radius
-export pseudo_cutoff_radius
-export local_potential_real
-export projector_real
-export chi_function_real
-export valence_charge_density_real
-export core_charge_density_real
-export local_potential_fourier
-export projector_fourier
-export chi_function_fourier
-export valence_charge_density_fourier
-export core_charge_density_fourier
-export pseudo_energy_correction
+export has_quantity
+export get_quantity
+export cutoff_radius
+export psp_quantity_evaluator
+export psp_energy_correction
 export angular_momenta
 export relativistic_treatment
 export formalism
-export projector_radial_indices
-export chi_function_radial_indices
 include("psp/psp.jl")
 
 export NumericPsP

--- a/src/common/spherical_bessel.jl
+++ b/src/common/spherical_bessel.jl
@@ -23,7 +23,7 @@ function fast_sphericalbesselj(l::Integer)
     l == 3 && return fast_sphericalbesselj3
     l == 4 && return fast_sphericalbesselj4
     l == 5 && return fast_sphericalbesselj5
-    return error("The case l = $l is not implemented")
+    return x -> sphericalbesselj(l, x)
 end
 
 function fast_sphericalbesselj0(x::T)::T where {T<:Real}

--- a/src/common/truncation.jl
+++ b/src/common/truncation.jl
@@ -8,8 +8,8 @@ function find_truncation_index(f::AbstractVector, tol)
             break
         end
     end
-    return isnothing(i_trunc) ? lastindex(f) : length(f) - i_trunc - 1
+    return isnothing(i_trunc) ? max(lastindex(f), firstindex(f)) : max(lastindex(f) - i_trunc - 1, firstindex(f))
 end
 
-find_truncation_index(f::AbstractVector, ::Nothing) = lastindex(f)
+find_truncation_index(f::AbstractVector, ::Nothing) = max(lastindex(f), firstindex(f))
 find_truncation_index(::Nothing, ::Nothing) = nothing

--- a/src/file/file.jl
+++ b/src/file/file.jl
@@ -16,9 +16,9 @@ function elemental_symbol(file::PsPFile)::AbstractString end
 # The maximum angular momentum channel contained in the file
 function max_angular_momentum(file::PsPFile)::Integer end
 # The number of non-local projectors for angular momentum `l` contained in the file
-function n_projector_radials(file::PsPFile, l::Integer)::Integer end
+function n_beta_projector_radials(file::PsPFile, l::Integer)::Integer end
 # The number of chi functions for angular momentum `l` contained in the file
-function n_chi_function_radials(file::PsPFile, l::Integer)::Integer end
+function n_chi_projector_radials(file::PsPFile, l::Integer)::Integer end
 # The pseudo-atomic valence charge
 function valence_charge(file::PsPFile)::Real end
 # Whether the file contains a norm-conserving pseudopotential
@@ -60,12 +60,12 @@ function max_angular_momentum(file::PsPFile) end
 Number of radial parts of the Kleinman-Bylander projectors `Rl(r)` at a given angular
 momentum.
 """
-function n_projector_radials(file::PsPFile, l) end
+function n_beta_projector_radials(file::PsPFile, l) end
 
 """
 Number of radial parts of the chi-functions with angular momentum `l`.
 """
-function n_chi_function_radials(file::PsPFile, l) end
+function n_chi_projector_radials(file::PsPFile, l) end
 
 """
 Pseudo-atomic valence charge.
@@ -117,48 +117,48 @@ relativistic_treatment(file::PsPFile)::Symbol = has_spin_orbit(file) ? :full : :
 Number of radial parts of the Kleinman-Bylander nonlocal projectors at all angular momenta
 up to the maximum angular momentum channel.
 """
-function n_projector_radials(file::PsPFile)
-    return sum(l -> n_projector_radials(file, l), 0:max_angular_momentum(file); init=0)
+function n_beta_projector_radials(file::PsPFile)
+    return sum(l -> n_beta_projector_radials(file, l), 0:max_angular_momentum(file); init=0)
 end
 
 """
 Number of angular parts `Yₗₘ(r̂)` of the Kleinman-Bylander projectors `Rₗₙ(|r|)Yₗₘ(r̂)` at a
 given angular momentum `l`.
 """
-function n_projector_angulars(file::PsPFile, l)
+function n_beta_projector_angulars(file::PsPFile, l)
     # for angular momentum l, magnetic q.n. m ∈ -l:l
-    return n_projector_radials(file, l) * (2l + 1)
+    return n_beta_projector_radials(file, l) * (2l + 1)
 end
 
 """
 Number of angular parts of the Kleinman-Bylander projectors at all angular momenta up
 to the maximum angular momentum channel.
 """
-function n_projector_angulars(file::PsPFile)
-    return sum(l -> n_projector_angulars(file, l), 0:max_angular_momentum(file); init=0)
+function n_beta_projector_angulars(file::PsPFile)
+    return sum(l -> n_beta_projector_angulars(file, l), 0:max_angular_momentum(file); init=0)
 end
 
 """
 Number chi-functions at all angular momenta up to the maximum angular momentum
 channel.
 """
-function n_chi_function_radials(file::PsPFile)
-    return sum(l -> n_chi_function_radials(file, l), 0:max_angular_momentum(file); init=0)
+function n_chi_projector_radials(file::PsPFile)
+    return sum(l -> n_chi_projector_radials(file, l), 0:max_angular_momentum(file); init=0)
 end
 
 """
 Number of angular parts of the chi-functions with angular momentum `l`.
 """
-function n_chi_function_angulars(file::PsPFile, l)
+function n_chi_projector_angulars(file::PsPFile, l)
     # for angular momentum l, magnetic q.n. m ∈ -l:l
-    return n_chi_function_radials(file, l) * (2l + 1)
+    return n_chi_projector_radials(file, l) * (2l + 1)
 end
 
 """
 Number of angular parts of the chi-functions at all angular momenta up
 to the maximum angular momentum channel.
 """
-function n_chi_function_angulars(file::PsPFile)
+function n_chi_projector_angulars(file::PsPFile)
     return sum(l -> n_pseudo_orbtial_angulars(file, l), 0:max_angular_momentum(file);
                init=0)
 end
@@ -184,6 +184,6 @@ function Base.show(io::IO, ::MIME"text/plain", file::PsPFile)
     @printf "%032s: %s\n" "relativistic treatment" relativistic_treatment(file)
     @printf "%032s: %s\n" "non-linear core correction" has_core_density(file)
     @printf "%032s: %d\n" "maximum angular momentum" max_angular_momentum(file)
-    @printf "%032s: %d\n" "number of projectors" n_projector_radials(file)
-    @printf "%032s: %d" "number of chi functions" n_chi_function_radials(file)
+    @printf "%032s: %d\n" "number of projectors" n_beta_projector_radials(file)
+    @printf "%032s: %d" "number of chi functions" n_chi_projector_radials(file)
 end

--- a/src/file/hgh.jl
+++ b/src/file/hgh.jl
@@ -106,5 +106,5 @@ is_ultrasoft(::HghFile)::Bool = false
 is_paw(::HghFile)::Bool = false
 valence_charge(psp::HghFile)::Float64 = sum(psp.zion)
 max_angular_momentum(psp::HghFile)::Int = psp.lmax
-n_projector_radials(psp::HghFile, l::Int)::Int = size(psp.h[l + 1], 1)
-n_chi_function_radials(::HghFile, l::Int)::Int = 0
+n_beta_projector_radials(psp::HghFile, l::Int)::Int = size(psp.h[l + 1], 1)
+n_chi_projector_radials(::HghFile, l::Int)::Int = 0

--- a/src/file/psp8.jl
+++ b/src/file/psp8.jl
@@ -87,7 +87,7 @@ function psp8_parse_header(io::IO)
                       rchrg, fchrg, qchrg, nproj, extension_switch, nprojso)
 end
 
-function psp8_parse_projector_block(io, nproj, mmax)
+function psp8_parse_beta_projector_block(io, nproj, mmax)
     # The first line of each projector block contains first the angular momentum of the
     # projectors then the "KB energies" (projector coupling constants) among the projectors
     # in the block
@@ -129,7 +129,7 @@ function psp8_parse_v_local_block(io, mmax)
 end
 
 function psp8_parse_main_blocks(io, mmax, nproj, lmax, lloc)
-    projector_blocks = []
+    beta_projector_blocks = []
     v_local_block = ()
 
     if lmax < lloc  # The local potential does not replace an angular momentum channel
@@ -153,16 +153,16 @@ function psp8_parse_main_blocks(io, mmax, nproj, lmax, lloc)
             if lloc <= lmax
                 # If the local potential is mixed in with the projectors, add an empty block
                 # to maintain proper angular momentum indexing
-                push!(projector_blocks, (; l=block_l, rgrid=nothing, projectors=[], ekb=[]))
+                push!(beta_projector_blocks, (; l=block_l, rgrid=nothing, projectors=[], ekb=[]))
             end
         else
-            block = psp8_parse_projector_block(io, nproj, mmax)
-            push!(projector_blocks, block)
+            block = psp8_parse_beta_projector_block(io, nproj, mmax)
+            push!(beta_projector_blocks, block)
         end
     end
 
-    projectors = [block.projectors for block in projector_blocks]
-    ekb = [block.ekb for block in projector_blocks]
+    projectors = [block.projectors for block in beta_projector_blocks]
+    ekb = [block.ekb for block in beta_projector_blocks]
 
     return (; v_local_block.rgrid, v_local_block.v_local, projectors, ekb)
 end
@@ -170,14 +170,14 @@ end
 function psp8_parse_spin_orbit_blocks(io, mmax, nprojso, lmax)
     # Spin-orbit coupling projector blocks have the same shape as "normal" projector blocks,
     # but there is no spin-orbit local potential.
-    projector_blocks = []
+    beta_projector_blocks = []
     for _ in 1:lmax
-        block = psp8_parse_projector_block(io, nprojso, mmax)
-        push!(projector_blocks, block)
+        block = psp8_parse_beta_projector_block(io, nprojso, mmax)
+        push!(beta_projector_blocks, block)
     end
 
-    projectors = [block.projectors for block in projector_blocks]
-    ekb = [block.ekb for block in projector_blocks]
+    projectors = [block.projectors for block in beta_projector_blocks]
+    ekb = [block.ekb for block in beta_projector_blocks]
 
     return (; projectors, ekb)
 end
@@ -289,5 +289,5 @@ is_ultrasoft(file::Psp8File)::Bool = false
 is_paw(file::Psp8File)::Bool = false
 valence_charge(file::Psp8File)::Float64 = file.header.zion
 max_angular_momentum(file::Psp8File)::Int = file.header.lmax
-n_projector_radials(file::Psp8File, l::Int)::Int = file.header.nproj[l + 1]
-n_chi_function_radials(::Psp8File, l::Int)::Int = 0
+n_beta_projector_radials(file::Psp8File, l::Int)::Int = file.header.nproj[l + 1]
+n_chi_projector_radials(::Psp8File, l::Int)::Int = 0

--- a/src/file/upf.jl
+++ b/src/file/upf.jl
@@ -356,9 +356,9 @@ has_spin_orbit(file::UpfFile)::Bool = file.header.has_so
 has_core_density(file::UpfFile)::Bool = file.header.core_correction
 valence_charge(file::UpfFile)::Float64 = file.header.z_valence
 max_angular_momentum(file::UpfFile)::Int = file.header.l_max
-function n_projector_radials(file::UpfFile, l::Int)::Int
+function n_beta_projector_radials(file::UpfFile, l::Int)::Int
     return count(beta -> beta.angular_momentum == l, file.nonlocal.betas)
 end
-function n_chi_function_radials(file::UpfFile, l::Int)::Int
+function n_chi_projector_radials(file::UpfFile, l::Int)::Int
     return file.header.number_of_wfc == 0 ? 0 : count(chi -> chi.l == l, file.pswfc)
 end

--- a/src/psp/hgh.jl
+++ b/src/psp/hgh.jl
@@ -8,9 +8,9 @@ struct HghPsP{T} <: AnalyticalPsP
     "SHA1 Checksum"
     checksum::Vector{UInt8}
     "Atomic charge"
-    Zatom::Union{Nothing,T}
+    Zatom::Union{Nothing,Int}
     "Valence charge"
-    Zval::T
+    Zval::Int
     "Maximum angular momentum"
     lmax::Int
     "Radial cutoff for the local part of the pseudopotential"
@@ -41,28 +41,45 @@ function HghPsP(file::HghFile)
 end
 
 identifier(psp::HghPsP)::String = bytes2hex(psp.checksum)
-element(psp::HghPsP)::String = isnothing(psp.Zatom) ? "unknown" :
-                               PeriodicTable.elements[Int(psp.Zatom)].symbol
+element(psp::HghPsP) = isnothing(psp.Zatom) ? nothing : PeriodicTable.elements[Int(psp.Zatom)]
 has_spin_orbit(::HghPsP)::Bool = false
-has_core_density(::HghPsP)::Bool = false
-has_valence_density(::HghPsP)::Bool = false
-has_chi_functions(::HghPsP)::Bool = false
 is_norm_conserving(::HghPsP)::Bool = true
 is_ultrasoft(::HghPsP)::Bool = false
 is_paw(::HghPsP)::Bool = false
 valence_charge(psp::HghPsP) = psp.Zval
 atomic_charge(psp::HghPsP) = psp.Zatom
 max_angular_momentum(psp::HghPsP)::Int = psp.lmax
-n_projector_radials(psp::HghPsP, l::Int)::Int = size(psp.D[l], 1)
-n_chi_function_radials(::HghPsP, ::Int)::Int = 0
 
-local_potential_cutoff_radius(::HghPsP; tol=nothing) = Inf
-projector_cutoff_radius(::HghPsP, ::Int, ::Int; tol=nothing) = Inf
-chi_function_cutoff_radius(::HghPsP, ::Int, ::Int; tol=nothing) = Inf
-valence_charge_density_cutoff_radius(::HghPsP; tol=nothing) = Inf
-core_charge_density_cutoff_radius(::HghPsP; tol=nothing) = Inf
+has_quantity(::AbstractPsPQuantity, ::HghPsP) = false
+has_quantity(::LocalPotential, ::HghPsP) = true
+has_quantity(::BetaProjector, ::HghPsP) = true
+has_quantity(::BetaCoupling, ::HghPsP) = true
 
-projector_coupling(psp::HghPsP, l::Int) = psp.D[l]
+get_quantity(::BetaCoupling, psp::HghPsP) = psp.D
+get_quantity(::BetaCoupling, psp::HghPsP, l) = psp.D[l]
+get_quantity(::BetaCoupling, psp::HghPsP, l, n) = psp.D[l][n,n]
+get_quantity(::BetaCoupling, psp::HghPsP, l, n, m) = psp.D[l][n,m]
+
+n_radials(::BetaProjector, psp::HghPsP, l::Int) = size(psp.D[l], 1)
+n_radials(::ChiProjector, ::HghPsP, ::Int) = 0
+
+function cutoff_radius(q::AbstractPsPQuantity, psp::HghPsP; f=nothing, tol=nothing)
+    return has_quantity(q, psp) ? nothing : Inf
+end
+cutoff_radius(q::PsPProjector, psp::HghPsP, l, n; tol=nothing) = cutoff_radius(q, psp)
+
+function psp_quantity_evaluator(::RealSpace, ::LocalPotential, psp::HghPsP)
+    return local_potential_real(psp)
+end
+function psp_quantity_evaluator(::RealSpace, ::BetaProjector, psp::HghPsP, l, n)
+    return beta_projector_real(psp, l, n)
+end
+function psp_quantity_evaluator(::FourierSpace, ::LocalPotential, psp::HghPsP)
+    return local_potential_fourier(psp)
+end
+function psp_quantity_evaluator(::FourierSpace, ::BetaProjector, psp::HghPsP, l, n)
+    return beta_projector_fourier(psp, l, n)
+end
 
 @doc raw"""
 The local potential of a HGH pseudopotentials in reciprocal space
@@ -70,9 +87,9 @@ can be brought to the form ``Q(t) / (t^2 exp(t^2 / 2))``
 where ``x = r_\text{loc} q`` and `Q`
 is a polynomial of at most degree 8. This function returns `Q`.
 """
-@inline function local_potential_polynomial_fourier(psp::HghPsP, x::T)::T where {T<:Real}
-    rloc = psp.rloc
-    Zval = psp.Zval
+@inline function local_potential_polynomial_fourier(psp::HghPsP, x::T) where {T<:Real}
+    rloc::T = psp.rloc
+    Zval::T = psp.Zval
 
     # The polynomial prefactor P(t) (as used inside the { ... } brackets of equation
     # (5) of the HGH98 paper)
@@ -81,13 +98,13 @@ is a polynomial of at most degree 8. This function returns `Q`.
          + psp.cloc[3] * (15 - 10x^2 + x^4)
          + psp.cloc[4] * (105 - 105x^2 + 21x^4 - x^6))
 
-    return 4π * rloc^2 * (-Zval + sqrt(π / 2) * rloc * x^2 * P)
+    return 4T(π) * rloc^2 * (-Zval + sqrt(T(π) / 2) * rloc * x^2 * P)
 end
 
 # [GTH98] (6) except they do it with plane waves normalized by 1/sqrt(Ω).
 function local_potential_fourier(psp::HghPsP)
-    function Vloc(q)
-        x = q * psp.rloc
+    function Vloc(q::T) where {T<:Real}
+        x::T = q * psp.rloc
         return local_potential_polynomial_fourier(psp, x) * exp(-x^2 / 2) / x^2
     end
     Vloc(Q::AbstractVector) = Vloc(norm(Q))
@@ -96,14 +113,12 @@ end
 
 # [GTH98] (1)
 function local_potential_real(psp::HghPsP)
-    function Vloc(r::T) where {T}
+    function Vloc(r::T)::T where {T<:Real}
         r += iszero(r) ? eps(T) : zero(T)  # quick hack for the division by zero below
         cloc = psp.cloc
         rr = r / psp.rloc
-        return convert(T,
-                       -psp.Zval / r * erf(rr / sqrt(T(2))) +
-                       exp(-rr^2 / 2) *
-                       (cloc[1] + cloc[2] * rr^2 + cloc[3] * rr^4 + cloc[4] * rr^6))
+        return -psp.Zval / r * erf(rr / sqrt(T(2))) +
+               exp(-rr^2 / 2) * (cloc[1] + cloc[2] * rr^2 + cloc[3] * rr^4 + cloc[4] * rr^6)
     end
     Vloc(R::AbstractVector) = Vloc(norm(R))
     return Vloc
@@ -114,45 +129,45 @@ The nonlocal projectors of a HGH pseudopotentials in reciprocal space
 can be brought to the form ``Q(t) exp(-t^2 / 2)`` where ``t = r_l q``
 and `Q` is a polynomial. This function returns `Q`.
 """
-@inline function projector_polynomial_fourier(psp::HghPsP, l::Int, n::Int,
-                                              x::T)::T where {T<:Real}
+@inline function beta_projector_polynomial_fourier(psp::HghPsP, l::Int, n::Int,
+                                              x::T) where {T<:Real}
     @assert 0 <= l <= length(psp.rnl) - 1
     @assert n > 0
-    rnl = psp.rnl[l]
-    common = 4π^(5 / 4) * sqrt(2^(l + 1) * rnl^3)
+    rnl::T = psp.rnl[l]
+    common::T = 4T(π)^(5 / T(4)) * sqrt(T(2^(l + 1)) * rnl^3)
 
     # Note: In the (l == 0 && i == 2) case the HGH paper has an error.
     #       The first 8 in equation (8) should not be under the sqrt-sign
     #       This is the right version (as shown in the GTH paper)
     (l == 0 && n == 1) && return convert(typeof(x), common)
-    (l == 0 && n == 2) && return common * 2 / sqrt(15) * (3 - x^2)
-    (l == 0 && n == 3) && return common * 4 / 3sqrt(105) * (15 - 10x^2 + x^4)
+    (l == 0 && n == 2) && return common * 2 / sqrt(T(15)) * (3 - x^2)
+    (l == 0 && n == 3) && return common * 4 / 3sqrt(T(105)) * (15 - 10x^2 + x^4)
     #
-    (l == 1 && n == 1) && return common * 1 / sqrt(3) * x
-    (l == 1 && n == 2) && return common * 2 / sqrt(105) * x * (5 - x^2)
-    (l == 1 && n == 3) && return common * 4 / 3sqrt(1155) * x * (35 - 14x^2 + x^4)
+    (l == 1 && n == 1) && return common * 1 / sqrt(T(3)) * x
+    (l == 1 && n == 2) && return common * 2 / sqrt(T(105)) * x * (5 - x^2)
+    (l == 1 && n == 3) && return common * 4 / 3sqrt(T(1155)) * x * (35 - 14x^2 + x^4)
     #
-    (l == 2 && n == 1) && return common * 1 / sqrt(15) * x^2
-    (l == 2 && n == 2) && return common * 2 / 3sqrt(105) * x^2 * (7 - x^2)
+    (l == 2 && n == 1) && return common * 1 / sqrt(T(15)) * x^2
+    (l == 2 && n == 2) && return common * 2 / 3sqrt(T(105)) * x^2 * (7 - x^2)
     #
-    (l == 3 && n == 1) && return common * 1 / sqrt(105) * x^3
+    (l == 3 && n == 1) && return common * 1 / sqrt(T(105)) * x^3
 
     return error("Not implemented for l=$l and i=$n")
 end
 
 # [HGH98] (7-15) except they do it with plane waves normalized by 1/sqrt(Ω).
-function projector_fourier(psp::HghPsP, l::Int, n::Int)
-    function β(q::T) where {T}
+function beta_projector_fourier(psp::HghPsP, l::Int, n::Int)
+    function β(q::T) where {T<:Real}
         x::T = q * psp.rnl[l]
-        return projector_polynomial_fourier(psp, l, n, x) * exp(-x^2 / 2)
+        return beta_projector_polynomial_fourier(psp, l, n, x) * exp(-x^2 / T(2))
     end
     β(Q::AbstractVector) = β(norm(Q))
     return β
 end
 
 # [HGH98] (3)
-function projector_real(psp::HghPsP, l::Int, n::Int)
-    function β(r::T) where {T}
+function beta_projector_real(psp::HghPsP, l::Int, n::Int)
+    function β(r::T) where {T<:Real}
         rnl = T(psp.rnl[l])
         ired = (4n - 1) / T(2)
         return sqrt(T(2)) * r^(l + 2(n - 1)) * exp(-r^2 / 2rnl^2) / rnl^(l + ired) /
@@ -162,15 +177,15 @@ function projector_real(psp::HghPsP, l::Int, n::Int)
     return β
 end
 
-function pseudo_energy_correction(T::Type, psp::HghPsP)
+function psp_energy_correction(T::Type{<:Real}, psp::HghPsP)
     # By construction we need to compute the DC component of the difference
     # of the Coulomb potential (-Z/G^2 in Fourier space) and the pseudopotential
     # i.e. -4πZ/(ΔG)^2 -  eval_psp_local_fourier(psp, ΔG) for ΔG → 0. This is:
     cloc_coeffs = [1, 3, 15, 105]
-    difference_DC = (psp.Zval * psp.rloc^2 / 2 +
-                     sqrt(π / 2) * psp.rloc^3 * sum(cloc_coeffs .* psp.cloc))
+    difference_DC = (T(psp.Zval) * T(psp.rloc)^2 / 2 +
+                     sqrt(T(π) / 2) * T(psp.rloc)^3 * T(sum(cloc_coeffs .* psp.cloc)))
 
     # Multiply by number of electrons and 4π (spherical Hankel prefactor)
     # to get energy per unit cell
-    return T(4π * difference_DC)
+    return 4T(π) * difference_DC
 end

--- a/src/psp/norm_conserving.jl
+++ b/src/psp/norm_conserving.jl
@@ -5,9 +5,9 @@ struct NormConservingPsP{T} <: NumericPsP{T}
     "SHA1 Checksum"
     checksum::Vector{UInt8}
     "Total charge."
-    Zatom::T
+    Zatom::Int
     "Valence charge."
-    Zval::T
+    Zval::Int
     "Maximum angular momentum."
     lmax::Int
     "Radial mesh."

--- a/src/psp/psp.jl
+++ b/src/psp/psp.jl
@@ -13,9 +13,9 @@ function elemental_symbol(psp::AbstractPsP)::AbstractString end
 # The maximum angular momentum channel
 function max_angular_momentum(psp::AbstractPsP)::Integer end
 # The number of non-local projector radial parts for angular momentum `l`
-function n_projector_radials(psp::AbstractPsP, l::Integer)::Integer end
+function n_beta_projector_radials(psp::AbstractPsP, l::Integer)::Integer end
 # The number of chi function radial parts for angular momentum `l`
-function n_chi_function_radials(psp::AbstractPsP, l::Integer)::Integer end
+function n_chi_projector_radials(psp::AbstractPsP, l::Integer)::Integer end
 # The pseudo-atomic valence charge
 function valence_charge(psp::AbstractPsP)::Real end
 # The charge of the atom which was pseudized (e.g. 8 for Oxygen)
@@ -36,17 +36,17 @@ function has_core_density(psp::AbstractPsP)::Bool end
 function has_valence_density(psp::AbstractPsP)::Bool end
 # Whether pseudopotential contains chi functions for the valence electrons (i.e.
 # has support for computing tailored orbital-projected quantitites)
-function has_chi_functions(psp:AbstractPsP)::Bool end
+function has_chi_projectors(psp:AbstractPsP)::Bool end
 # The projector coupling coefficients for angular momentum `l`
-function projector_coupling(psp::AbstractPsP, l::Integer)::Matrix{Real} end
+function beta_projector_coupling(psp::AbstractPsP, l::Integer)::Matrix{Real} end
 # Radial distance where the local potential decays to zero within a tolerance `tol`
 function local_potential_cutoff_radius(psp::AbstractPsP; tol) end
 # Radial distance where the `n`th non-local projector at angular momentum `l` decays to
 # zero within a tolerance `tol`
-function projector_cutoff_radius(psp::AbstractPsP, l, n; tol) end
+function beta_projector_cutoff_radius(psp::AbstractPsP, l, n; tol) end
 # Radial distance where the `n`th chi function at angular momentum `l` decays to
 # zero within a tolerance `tol`
-function chi_function_cutoff_radius(psp::AbstractPsP, l, n; tol) end
+function chi_projector_cutoff_radius(psp::AbstractPsP, l, n; tol) end
 # Radial distance where the valence charge density decays to zero within a tolerance `tol`
 function valence_charge_density_cutoff_radius(psp::AbstractPsP; tol) end
 # Radial distance where the core charge density decays to zero within a tolerance `tol`
@@ -55,10 +55,10 @@ function core_charge_density_cutoff_radius(psp::AbstractPsP; tol) end
 function local_potential_real(psp::AbstractPsP) end
 # Returns a function which evaulates the `n`th non-local projector with angular momentum
 # `l` at a real-space radial coordinate
-function projector_real(psp::AbstractPsP, l, n) end
+function beta_projector_real(psp::AbstractPsP, l, n) end
 # Returns a function which evaulates the `n`th chi function with angular momentum
 # `l` at a real-space radial coordinate
-function chi_function_real(psp::AbstractPsP, l, n) end
+function chi_projector_real(psp::AbstractPsP, l, n) end
 # Returns a function which evaulates the valence charge density at a real-space
 # radial coordinate
 function valence_charge_density_real(psp::AbstractPsP) end
@@ -70,10 +70,10 @@ function core_charge_density_real(psp::AbstractPsP) end
 function local_potential_fourier(psp::AbstractPsP) end
 # Returns a function which evaulates the `n`th non-local projector with angular momentum
 # `l` at a fourier-space radial coordinate
-function projector_fourier(psp::AbstractPsP, l, n) end
+function beta_projector_fourier(psp::AbstractPsP, l, n) end
 # Returns a function which evaulates the `n`th chi function with angular momentum
 # `l` at a fourier-space radial coordinate
-function chi_function_fourier(psp::AbstractPsP, l, n) end
+function chi_projector_fourier(psp::AbstractPsP, l, n) end
 # Returns a function which evaulates the valence charge density at a fourier-space
 # radial coordinate
 function valence_charge_density_fourier(psp::AbstractPsP) end
@@ -81,7 +81,7 @@ function valence_charge_density_fourier(psp::AbstractPsP) end
 # radial coordinate
 function core_charge_density_fourier(psp::AbstractPsP) end
 # The pseudo-potential energy correction
-function pseudo_energy_correction(psp::AbstractPsP) end
+function psp_energy_correction(psp::AbstractPsP) end
 ```
 """
 abstract type AbstractPsP end
@@ -102,16 +102,7 @@ Maximum angular momentum channel of the pseudopotential.
 """
 function max_angular_momentum(psp::AbstractPsP) end
 
-"""
-Number of radial parts `Rₗₙ(|r|)` of the Kleinman-Bylander projectors `Rₗₙ(|r|)Yₗₘ(r̂)` at a
-given angular momentum `l`.
-"""
-function n_projector_radials(psp::AbstractPsP, l) end
-
-"""
-Number of radial parts of the chi-functions with angular momentum `l`.
-"""
-function n_chi_function_radials(psp::AbstractPsP, l) end
+function n_radials(quantity::AbstractPsPQuantity, psp::AbstractPsP, l) end
 
 """
 Pseudo-atomic valence charge.
@@ -143,131 +134,18 @@ Whether the pseudopotential contains relativistic spin-orbit coupling data.
 """
 function has_spin_orbit(psp::AbstractPsP) end
 
-"""
-Whether the pseudopotential contains non-linear core correction data (model core charge
-density).
-"""
-function has_core_density(psp::AbstractPsP) end
+function cutoff_radius(q::AbstractPsPQuantity, psp::AbstractPsP; tol=nothing) end
+function cutoff_radius(q::PsPProjector, psp::AbstractPsP, l, n; tol=nothing) end
 
-"""
-Whether the pseudopotential contains valence charge density data.
-"""
-function has_valence_density(psp::AbstractPsP) end
-
-"""
-Whether the pseudopotential contains pseudoatomic orbitals.
-"""
-function has_chi_functions(psp::AbstractPsP) end
-
-"""
-Projector coupling matrix at angular momentum `l`.
-"""
-function projector_coupling(psp::AbstractPsP, l) end
-
-"""
-Cutoff radius of the local potential in real-space.
-"""
-function local_potential_cutoff_radius(psp::AbstractPsP; tol=nothing) end
-
-"""
-Cutoff radius of the `n`th Kleinman-Bylander non-local projector at angular momentum `l` in
-real-space.
-"""
-function projector_cutoff_radius(psp::AbstractPsP, l::Int, n::Int; tol=nothing) end
-
-"""
-Cutoff radius of the `n`th chi function at angular momentum `l` in real-space.
-"""
-function chi_function_cutoff_radius(psp::AbstractPsP, l::Int, n::Int; tol=nothing) end
-
-"""
-Cutoff radius of the valence charge density in real-space.
-"""
-function valence_charge_density_cutoff_radius(psp::AbstractPsP; tol=nothing) end
-
-"""
-Cutoff radius of the core charge density in real-space.
-"""
-function core_charge_density_cutoff_radius(psp::AbstractPsP; tol=nothing) end
-
-"""
-Local part of the pseudopotential evaluated at real-space point `r`.
-"""
-function local_potential_real(psp::AbstractPsP)
-    return _ -> nothing
-end
-
-"""
-The `n`th nonlocal Kleinman-Bylander projector at angular momentum `l` evaluated at
-real-space point `r`.
-"""
-function projector_real(psp::AbstractPsP, l::Integer, n::Integer)
-    return _ -> nothing
-end
-
-"""
-The `n`th chi function at angular momentum `l` evaulated at real-space point `r`.
-"""
-function chi_function_real(psp::AbstractPsP, l::Integer, n::Integer)
-    return _ -> nothing
-end
-
-"""
-Pseudo-atomic valence charge density evaluated at real-space point `r`.
-"""
-function valence_charge_density_real(psp::AbstractPsP)
-    return _ -> nothing
-end
-
-"""
-Model core charge density evaluated at real-space point `r`.
-"""
-function core_charge_density_real(psp::AbstractPsP)
-    return _ -> nothing
-end
-
-"""
-Local part of the pseudopotential evaluated at reciprocal-space point `q`.
-"""
-function local_potential_fourier(psp::AbstractPsP)
-    return _ -> nothing
-end
-
-"""
-The `n`th nonlocal Kleinman-Bylander projector at angular momentum `l` evaluated at
-reciprocal-space point `q`.
-"""
-function projector_fourier(psp::AbstractPsP, l::Integer, n::Integer)
-    return _ -> nothing
-end
-
-"""
-The `n`th chi function at angular momentum `l` evaulated at reciprocal-space
-point `q`.
-"""
-function chi_function_fourier(psp::AbstractPsP, l::Integer, n::Integer)
-    return _ -> nothing
-end
-
-"""
-Pseudo-atomic valence charge density evaluated at reciprocal-space point `q`.
-"""
-function valence_charge_density_fourier(psp::AbstractPsP)
-    return _ -> nothing
-end
-
-"""
-Model core charge density evaluated at reciprocal-space point `q`.
-"""
-function core_charge_density_fourier(psp::AbstractPsP)
-    return _ -> nothing
-end
+function psp_quantity_evaluator(s::EvaluationSpace, q::AbstractPsPQuantity,
+                                psp::AbstractPsP) end
+function psp_quantity_evaluator(s::EvaluationSpace, q::PsPProjector, psp::AbstractPsP, l, n) end
 
 """
 Pseudopotential energy correction (the DC component of the Fourier transform of the
 local part of the pseudopotential).
 """
-function pseudo_energy_correction(T::Type, psp::AbstractPsP) end
+function psp_energy_correction(T::Type, psp::AbstractPsP) end
 
 #!!! Convenience functions !!!#
 """
@@ -290,95 +168,26 @@ function formalism(psp::AbstractPsP)::Type
     is_paw(psp) && return ProjectorAugmentedWavePsP
 end
 
-"""
-Indices of projector radial parts at a given angular momentum.
-"""
-projector_radial_indices(psp::AbstractPsP, l) = 1:n_projector_radials(psp, l)
-
-"""
-Number of radial parts of the Kleinman-Bylander projectors at all angular momenta up
-to the maximum angular momentum channel.
-"""
-function n_projector_radials(psp::AbstractPsP)
-    return sum(l -> n_projector_radials(psp, l), angular_momenta(psp); init=0)
+function n_radials(q::PsPProjector, psp::AbstractPsP)
+    return sum(l -> n_radials(q, psp, l), angular_momenta(psp); init=0)
+end
+function n_angulars(q::PsPProjector, psp::AbstractPsP, l)
+    return (2l + 1) * n_radials(q, psp, l)
+end
+function n_angulars(q::PsPProjector, psp::AbstractPsP)
+    return sum(l -> n_angulars(q, psp, l), angular_momenta(psp); init=0)
 end
 
-"""
-Number of angular parts `Yₗₘ(r̂)` of the Kleinman-Bylander projectors `Rₗₙ(|r|)Yₗₘ(r̂)` at a
-given angular momentum `l`.
-"""
-function n_projector_angulars(psp::AbstractPsP, l)
-    # for angular momentum l, magnetic q.n. m ∈ -l:l
-    return n_projector_radials(psp::AbstractPsP, l) * (2l + 1)
-end
-
-"""
-Number of angular parts of the Kleinman-Bylander projectors at all angular momenta up
-to the maximum angular momentum channel.
-"""
-function n_projector_angulars(psp::AbstractPsP)
-    return sum(l -> n_projector_angulars(psp, l), angular_momenta(psp); init=0)
-end
-
-"""
-Indices of pseudo-atomic wavefunction radial parts at a given angular momentum.
-"""
-chi_function_radial_indices(psp::AbstractPsP, l) = 1:n_chi_function_radials(psp, l)
-
-"""
-Number chi-functions `Rₗₙ(|r|) * Yₗₘ(r̂)` at angular momenta `l` up to the
-maximum angular momentum channel.
-"""
-function n_chi_function_radials(psp::AbstractPsP)
-    return sum(l -> n_chi_function_radials(psp, l), angular_momenta(psp); init=0)
-end
-
-"""
-Number of angular parts of the chi-functions with angular momentum `l`.
-"""
-function n_chi_function_angulars(psp::AbstractPsP, l)
-    # for angular momentum l, magnetic q.n. m ∈ -l:l
-    return n_chi_function_radials(psp::AbstractPsP, l) * (2l + 1)
-end
-
-"""
-Number of angular parts of the chi-functions at all angular momenta up
-to the maximum angular momentum channel.
-"""
-function n_chi_function_angulars(psp::AbstractPsP)
-    return sum(l -> n_pseudo_orbtial_angulars(psp, l), angular_momenta(psp); init=0)
-end
-
-function projector_cutoff_radius(psp::AbstractPsP, l::Int; f=minimum, tol=nothing)
-    cutoff_radii = map(n -> projector_cutoff_radius(psp, l, n; tol),
-                       projector_radial_indices(psp, l))
+function cutoff_radius(q::PsPProjector, l::Int; f=minimum, tol=nothing)
+    cutoff_radii = map(n -> cutoff_radius(q, psp, l, n; tol), 1:n_radials(q, psp, l))
     cutoff_radii = filter(!isnothing, cutoff_radii)
-    isempty(cutoff_radii) && return nothing
-    return f(cutoff_radii)
+    return isempty(cutoff_radii) ? nothing : f(cutoff_radii)
 end
 
-function projector_cutoff_radius(psp::AbstractPsP; f=minimum, tol=nothing)
-    cutoff_radii = map(l -> projector_cutoff_radius(psp, l; tol),
-                       angular_momenta(psp))
+function cutoff_radius(q::PsPProjector; f=minimum, tol=nothing)
+    cutoff_radii = map(n -> cutoff_radius(q, psp, l; tol), angular_momenta(psp))
     cutoff_radii = filter(!isnothing, cutoff_radii)
-    isempty(cutoff_radii) && return nothing
-    return f(cutoff_radii)
-end
-
-function chi_function_cutoff_radius(psp::AbstractPsP, l::Int; f=minimum, tol=nothing)
-    cutoff_radii = map(n -> chi_function_cutoff_radius(psp, l, n; tol),
-                       chi_function_radial_indices(psp, l))
-    cutoff_radii = filter(!isnothing, cutoff_radii)
-    isempty(cutoff_radii) && return nothing
-    return f(cutoff_radii)
-end
-
-function chi_function_cutoff_radius(psp::AbstractPsP; f=minimum, tol=nothing)
-    cutoff_radii = map(l -> chi_function_cutoff_radius(psp, l; tol),
-                       angular_momenta(psp))
-    cutoff_radii = filter(!isnothing, cutoff_radii)
-    isempty(cutoff_radii) && return nothing
-    return f(cutoff_radii)
+    return isempty(cutoff_radii) ? nothing : f(cutoff_radii)
 end
 
 """
@@ -386,28 +195,13 @@ Find the cutoff radius for the pseudopotential. Supply a function `f` to determi
 of reduction over cutoff radii for different quantities is performed. Supply `tol` if
 you'd like to truncate the quantities where they decay to `|f| < tol`.
 """
-function pseudo_cutoff_radius(psp::AbstractPsP; f=minimum, tol=nothing)
-    cutoff_radii = [local_potential_cutoff_radius(psp; tol),
-                    projector_cutoff_radius(psp; f, tol),
-                    chi_function_cutoff_radius(psp; f, tol),
-                    valence_charge_density_cutoff_radius(psp; tol),
-                    core_charge_density_cutoff_radius(psp; tol)]
+function cutoff_radius(psp::AbstractPsP,
+                       quantities=[ValenceChargeDensity(), CoreChargeDensity(),
+                                   BetaProjector(), ChiProjector(), LocalPotential()];
+                       f=minimum, tol=nothing)
+    cutoff_radii = map(q -> cutoff_radius(q, psp; tol), quantities)
     cutoff_radii = filter(!isnothing, cutoff_radii)
-    return f(cutoff_radii)
-end
-
-"""
-Projector coupling constant between the `n`th and `m`th projector with angular momentum `l`.
-"""
-function projector_coupling(psp::AbstractPsP, l::Int, n::Int, m::Int)
-    return projector_coupling(psp, l)[n, m]
-end
-
-"""
-Projector coupling constant between the `n`th projector with angular momentum `l` itself.
-"""
-function projector_coupling(psp::AbstractPsP, l::Int, n::Int)
-    return projector_coupling(psp, l, n, n)
+    return isempty(cutoff_radii) ? nothing : f(cutoff_radii)
 end
 
 Base.Broadcast.broadcastable(psp::AbstractPsP) = Ref(psp)
@@ -429,8 +223,8 @@ function Base.show(io::IO, ::MIME"text/plain", psp::AbstractPsP)
     @printf "%032s: %s\n" "element" element(psp)
     @printf "%032s: %f\n" "valence charge" valence_charge(psp)
     @printf "%032s: %s\n" "relativistic treatment" relativistic_treatment(psp)
-    @printf "%032s: %s\n" "non-linear core correction" has_core_density(psp)
+    @printf "%032s: %s\n" "non-linear core correction" has_quantity(CoreChargeDensity(), psp)
     @printf "%032s: %d\n" "maximum angular momentum" max_angular_momentum(psp)
-    @printf "%032s: %s\n" "number of projectors" n_projector_radials(psp)
-    @printf "%032s: %s" "number of chi functions" n_chi_function_radials(psp)
+    @printf "%032s: %s\n" "number of beta projectors" n_radials(BetaProjector(), psp)
+    @printf "%032s: %s" "number of chi projectors" n_radials(ChiProjector(), psp)
 end

--- a/src/psp/quantities.jl
+++ b/src/psp/quantities.jl
@@ -1,0 +1,25 @@
+abstract type AbstractPsPQuantity end
+
+abstract type PsPChargeDensity <: AbstractPsPQuantity end
+struct ValenceChargeDensity <: PsPChargeDensity end
+struct CoreChargeDensity <: PsPChargeDensity end
+
+abstract type PsPProjector <: AbstractPsPQuantity end
+struct BetaProjector <: PsPProjector end
+struct ChiProjector <: PsPProjector end
+
+abstract type PsPCoupling <: AbstractPsPQuantity end
+struct BetaCoupling <: PsPCoupling end
+
+abstract type PsPPotential <: AbstractPsPQuantity end
+struct LocalPotential <: PsPPotential end
+
+struct AugmentationFunction <: AbstractPsPQuantity end
+
+abstract type EvaluationSpace end
+struct RealSpace <: EvaluationSpace end
+struct FourierSpace <: EvaluationSpace end
+
+# abstract type RelativisticTreatment end
+# struct ScalarRelativistic <: RelativisticTreatment end
+# struct FullyRelativistic <: RelativisticTreatment end

--- a/src/psp/ultrasoft.jl
+++ b/src/psp/ultrasoft.jl
@@ -2,10 +2,12 @@
 Type representing a numeric ultrasoft pseudopotential.
 """
 struct UltrasoftPsP{T} <: NumericPsP{T}
+    "Checksum"
+    checksum::Vector{UInt8}
     "Total charge"
-    Zatom::T
+    Zatom::Int
     "Valence charge"
-    Zval::T
+    Zval::Int
     "Maximum angular momentum"
     lmax::Int
     "Radial mesh"
@@ -123,8 +125,8 @@ function _upf_construct_us_internal(upf::UpfFile)
     else
         error("q_with_l == false and nqf == 0, unsure what to do...")
     end
-    return UltrasoftPsP{Float64}(nc.Zatom, nc.Zval, nc.lmax, nc.r, nc.dr, nc.Vloc, nc.β,
-                                 nc.D, nc.χ, Q, q, nc.ρcore, nc.ρval)
+    return UltrasoftPsP{Float64}(nc.checksum, nc.Zatom, nc.Zval, nc.lmax, nc.r, nc.dr,
+                                 nc.Vloc, nc.β, nc.D, nc.χ, Q, q, nc.ρcore, nc.ρval)
 end
 
 is_norm_conserving(::UltrasoftPsP)::Bool = false
@@ -152,12 +154,12 @@ end
 Augmentation charge in real-space.
 """
 function augmentation_real(psp::UltrasoftPsP, l::Int, n::Int, m::Int)
-    return build_interpolator_real(psp.Q[l][n,m], psp.r)
+    return build_interpolator_real(psp.Q[l][n, m], psp.r)
 end
 
 """
 Augmentation charge in fourier-space.
 """
 function augmentation_fourier(psp::UltrasoftPsP, l::Int, n::Int, m::Int)
-    return hankel_transform(psp.Q[l][n,m], 0, psp.r, psp.dr)
+    return hankel_transform(psp.Q[l][n, m], 0, psp.r, psp.dr)
 end

--- a/test/common.jl
+++ b/test/common.jl
@@ -44,13 +44,10 @@ import PseudoPotentialIO: fast_sphericalbesselj
     end
 
     @testset "fast_sphericalbesselj" begin
-        for l in 0:5
+        for l in 0:10
             for x in (rand(100) .* 100)
                 @test sphericalbesselj(l, x) ≈ fast_sphericalbesselj(l)(x) atol = 1e-8
             end
-        end
-        for l in 6:10
-            @test_throws ErrorException("The case l = $l is not implemented") fast_sphericalbesselj(l)
         end
     end
 

--- a/test/file/file.jl
+++ b/test/file/file.jl
@@ -4,8 +4,8 @@
         @test isa(format(file), AbstractString)
         @test isa(element(file), AbstractString)
         @test -1 <= max_angular_momentum(file) <= 5
-        @test 0 <= n_projector_radials(file)
-        @test 0 <= n_chi_function_radials(file)
+        @test 0 <= n_beta_projector_radials(file)
+        @test 0 <= n_chi_projector_radials(file)
         @test 0 <= valence_charge(file)  # <= element(file).number
         @test isa(is_norm_conserving(file), Bool)
         @test isa(is_ultrasoft(file), Bool)

--- a/test/file/hgh.jl
+++ b/test/file/hgh.jl
@@ -1,5 +1,5 @@
 #TODO test hgh file parser
-@testset "HGH" begin
+@testset "HGH File" begin
     @testset "c-q4.hgh" begin
         filename = "c-q4.hgh"
         file = load_psp_file(HGH_CASE_FILEPATHS[filename])

--- a/test/file/psp8.jl
+++ b/test/file/psp8.jl
@@ -1,4 +1,4 @@
-@testset "PSP8" begin
+@testset "PSP8 File" begin
     @testset "Internal data consistency" begin
         for filepath in values(PSP8_FILEPATHS)
             file = load_psp_file(filepath)

--- a/test/file/upf.jl
+++ b/test/file/upf.jl
@@ -1,4 +1,4 @@
-@testset "UPF" begin
+@testset "UPF File" begin
     @testset "Internal data consistency" begin
         @testset "$filepath" for filepath in UPF_FILEPATHS
             file = load_psp_file(filepath)

--- a/test/file/upf1.jl
+++ b/test/file/upf1.jl
@@ -1,4 +1,4 @@
-@testset "UPF v1.old" begin
+@testset "UPF v1.old File" begin
     @testset "Internal data consistency" begin
         for filepath in values(UPF1_CASE_FILEPATHS)
             file = load_psp_file(filepath)

--- a/test/file/upf2.jl
+++ b/test/file/upf2.jl
@@ -1,4 +1,4 @@
-@testset "UPF v2.0.1" begin
+@testset "UPF v2.0.1 File" begin
     @testset "Internal data consistency" begin
         for filepath in values(UPF2_CASE_FILEPATHS)
             psp = load_psp_file(filepath)

--- a/test/psp/numeric.jl
+++ b/test/psp/numeric.jl
@@ -1,9 +1,7 @@
-import PseudoPotentialIO: build_interpolator_real
-
 #TODO work on tightening tolerances
 @testset "Numeric" begin
     function local_potential_integrand(psp::NumericPsP, q)
-        Vloc = local_potential_real(psp)
+        Vloc = psp_quantity_evaluator(RealSpace(), LocalPotential(), psp)
         return r -> 4π * r * sphericalbesselj(0, q * r) * (r * Vloc(r) + psp.Zval)
     end
 
@@ -17,8 +15,8 @@ import PseudoPotentialIO: build_interpolator_real
             rmin = max(first(psp.r), eps(eltype(psp.r)))
 
             @testset "Local potential Fourier agrees with real" begin
-                rmax = local_potential_cutoff_radius(psp)
-                Vloc_fourier = local_potential_fourier(psp; tol)
+                rmax = cutoff_radius(LocalPotential(), psp)
+                Vloc_fourier = psp_quantity_evaluator(FourierSpace(), LocalPotential(), psp; tol)
                 for q in (0.01, 0.5, 2.5, 5.0, 10.0, 50.0)
                     ref = quadgk(local_potential_integrand(psp, q), rmin, rmax)[1] -
                         4π * psp.Zval / q^2
@@ -27,24 +25,24 @@ import PseudoPotentialIO: build_interpolator_real
             end
 
             @testset "Nonlocal projector Fouriers agree with real" begin
-                for l in 0:(psp.lmax), n in eachindex(psp.β[l])
-                    itp = build_interpolator_real(psp.β[l][n], psp.r)
-                    rmax = projector_cutoff_radius(psp, l, n)
-                    β_fourier = projector_fourier(psp, l, n; tol)
+                for l in angular_momenta(psp), n in 1:n_radials(BetaProjector(), psp, l)
+                    rmax = cutoff_radius(BetaProjector(), psp, l, n)
+                    β_real = psp_quantity_evaluator(RealSpace(), BetaProjector(), psp, l, n)
+                    β_fourier = psp_quantity_evaluator(FourierSpace(), BetaProjector(), psp, l, n; tol)
                     for q in (0.01, 0.5, 2.5, 5.0, 10.0, 50.0)
-                        ref = quadgk(radial_quantity_integrand(psp, itp, l, q), rmin, rmax)[1]
+                        ref = quadgk(radial_quantity_integrand(psp, β_real, l, q), rmin, rmax)[1]
                         @test ref ≈ β_fourier(q) rtol = 1e-1 atol = 1e-1
                     end
                 end
             end
 
             @testset "Core charge density Fourier agrees with real" begin
-                if !isnothing(psp.ρcore)
-                    itp = build_interpolator_real(psp.ρcore, psp.r)
-                    rmax = core_charge_density_cutoff_radius(psp)
-                    ρcore_fourier = core_charge_density_fourier(psp; tol)
+                if has_quantity(CoreChargeDensity(), psp)
+                    rmax = cutoff_radius(CoreChargeDensity(), psp)
+                    ρcore_real = psp_quantity_evaluator(RealSpace(), CoreChargeDensity(), psp)
+                    ρcore_fourier = psp_quantity_evaluator(FourierSpace(), CoreChargeDensity(), psp; tol)
                     for q in (0.01, 0.5, 2.5, 5.0, 10.0, 50.0)
-                        ref = quadgk(radial_quantity_integrand(psp, itp, 0, q), rmin, rmax)[1]
+                        ref = quadgk(radial_quantity_integrand(psp, ρcore_real, 0, q), rmin, rmax)[1]
                         @test ref ≈ ρcore_fourier(q) rtol = 1e-2 atol = 1e-2
                     end
                 end
@@ -52,18 +50,18 @@ import PseudoPotentialIO: build_interpolator_real
 
             @testset "Pseudo energy correction" begin
                 q_small = 1e-5
-                ref = local_potential_fourier(psp)(q_small) + 4π * psp.Zval / q_small^2
-                @test ref ≈ pseudo_energy_correction(Float64, psp) rtol = 1e-2 atol = 1e-2
+                ref = psp_quantity_evaluator(FourierSpace(), LocalPotential(), psp)(q_small) + 4π * psp.Zval / q_small^2
+                @test ref ≈ psp_energy_correction(Float64, psp) rtol = 1e-2 atol = 1e-2
             end
 
             @testset "Pseudo-atomic wavefunction Fouriers agree with real" begin
-                if !isnothing(psp.χ)
-                    for l in 0:(psp.lmax), n in eachindex(psp.χ[l])
-                        itp = build_interpolator_real(psp.χ[l][n], psp.r)
-                        rmax = chi_function_cutoff_radius(psp, l, n)
-                        χ_fourier = chi_function_fourier(psp, l, n; tol)
+                if has_quantity(ChiProjector(), psp)
+                    for l in angular_momenta(psp), n in 1:n_radials(ChiProjector(), psp, l)
+                        rmax = cutoff_radius(ChiProjector(), psp, l, n)
+                        χ_real = psp_quantity_evaluator(RealSpace(), ChiProjector(), psp, l, n)
+                        χ_fourier = psp_quantity_evaluator(FourierSpace(), ChiProjector(), psp, l, n; tol)
                         for q in (0.01, 0.5, 2.5, 5.0, 10.0, 50.0)
-                            ref = quadgk(radial_quantity_integrand(psp, itp, l, q), rmin, rmax)[1]
+                            ref = quadgk(radial_quantity_integrand(psp, χ_real, l, q), rmin, rmax)[1]
                             @test ref ≈ χ_fourier(q) rtol = 1e-1 atol = 1e-1
                         end
                     end
@@ -71,12 +69,12 @@ import PseudoPotentialIO: build_interpolator_real
             end
 
             @testset "Valence charge density Fouriers agree with real" begin
-                if !isnothing(psp.ρval)
-                    itp = build_interpolator_real(psp.ρval, psp.r)
-                    rmax = valence_charge_density_cutoff_radius(psp)
-                    ρval_fourier = valence_charge_density_fourier(psp; tol)
+                if has_quantity(ValenceChargeDensity(), psp)
+                    rmax = cutoff_radius(ValenceChargeDensity(), psp)
+                    ρval_real = psp_quantity_evaluator(RealSpace(), ValenceChargeDensity(), psp)
+                    ρval_fourier = psp_quantity_evaluator(FourierSpace(), ValenceChargeDensity(), psp; tol)
                     for q in (0.01, 0.5, 2.5, 5.0, 10.0, 50.0)
-                        ref = quadgk(radial_quantity_integrand(psp, itp, 0, q), rmin, rmax)[1]
+                        ref = quadgk(radial_quantity_integrand(psp, ρval_real, 0, q), rmin, rmax)[1]
                         @test ref ≈ ρval_fourier(q) rtol = 1e-2 atol = 1e-2
                     end
                 end

--- a/test/psp/psp.jl
+++ b/test/psp/psp.jl
@@ -10,84 +10,85 @@ function rotate_vector(q::Quaternion, u::AbstractVector)
     return [imag_part(q_v)...]
 end
 
+function rescale_vector(R, rmin, rmax)
+    isinf(rmin) && return R
+    isinf(rmax) && return R
+    return R / norm(R) * (rand() * (rmax - rmin) + rmin)
+end
+
+QUANTITIES = [ValenceChargeDensity(), CoreChargeDensity(), BetaProjector(),
+              ChiProjector(), BetaCoupling(), LocalPotential(),
+              AugmentationFunction()]
+
 @testset "AbstractPsP" begin
     @testset "$(splitpath(filepath)[end])" for filepath in TEST_FILEPATHS
         file = load_psp_file(filepath)
         if (is_norm_conserving(file) | is_ultrasoft(file)) & !has_spin_orbit(file)
             psp = load_psp(file)
-            @test isa(element(psp), AbstractString)
+            @test isa(element(psp), PeriodicTable.Element)
             @test -1 <= max_angular_momentum(psp) <= 5
-            @test 0 <= n_projector_radials(psp)
-            @test 0 <= n_chi_function_radials(psp)
-            @test 0 <= valence_charge(file)  # <= element(file).number
+            @test 0 <= n_radials(BetaProjector(), psp)
+            @test 0 <= n_radials(ChiProjector(), psp)
+            @test 0 <= valence_charge(file)
             @test isa(is_norm_conserving(psp), Bool)
             @test isa(is_ultrasoft(psp), Bool)
             @test isa(is_paw(psp), Bool)
             @test isa(has_spin_orbit(psp), Bool)
-            @test isa(has_core_density(psp), Bool)
+
+            for quantity in QUANTITIES
+                @test isa(has_quantity(quantity, psp), Bool)
+            end
 
             for l in angular_momenta(psp)
-                @test size(projector_coupling(psp, l)) ==
-                      (n_projector_radials(psp, l), n_projector_radials(psp, l))
-                @test eltype(projector_coupling(psp, l)) <: Real
-                for n in projector_radial_indices(psp, l)
-                    @test projector_coupling(psp, l, n, n) == projector_coupling(psp, l, n)
-                    for m in (n + 1):n_projector_radials(psp, l)
-                        @test isa(projector_coupling(psp, l, n, m), Real)
-                        @test projector_coupling(psp, l, n, m) ==
-                              projector_coupling(psp, l, m, n)
+                @test size(get_quantity(BetaCoupling(), psp, l)) ==
+                      (n_radials(BetaProjector(), psp, l),
+                       n_radials(BetaProjector(), psp, l))
+                @test eltype(get_quantity(BetaCoupling(), psp, l)) <: Real
+                for n in 1:n_radials(BetaProjector(), psp, l)
+                    @test get_quantity(BetaCoupling(), psp, l, n, n) ==
+                          get_quantity(BetaCoupling(), psp, l, n)
+                    for m in (n + 1):n_radials(BetaProjector(), psp, l)
+                        @test isa(get_quantity(BetaCoupling(), psp, l, n, m), Real)
+                        @test get_quantity(BetaCoupling(), psp, l, n, m) ==
+                              get_quantity(BetaCoupling(), psp, l, m, n)
                     end
                 end
-            end
-
-            R = rand(3)
-            r = norm(R)
-            R̂ = R ./ norm(r)
-            if isfinite(pseudo_cutoff_radius(psp))
-                r = r / sqrt(3) * pseudo_cutoff_radius(psp)
-            end
-            R = R̂ * r
-            R_rot = rotate_vector(random_versor(), R)
-
-            @test local_potential_real(psp)(R) ≈ local_potential_real(psp)(R_rot)
-            for l in angular_momenta(psp), n in projector_radial_indices(psp, l)
-                @test projector_real(psp, l, n)(R) ≈ projector_real(psp, l, n)(R_rot)
-            end
-            for l in angular_momenta(psp), n in chi_function_radial_indices(psp, l)
-                @test chi_function_real(psp, l, n)(R) ≈
-                      chi_function_real(psp, l, n)(R_rot)
-            end
-            ρval_R = valence_charge_density_real(psp)(R)
-            @test typeof(ρval_R) <: Union{Nothing,Real}
-            if !isnothing(ρval_R)
-                @test ρval_R ≈ valence_charge_density_real(psp)(R_rot)
-            end
-            ρcore_R = core_charge_density_real(psp)(R)
-            @test typeof(ρcore_R) <: Union{Nothing,Real}
-            if !isnothing(ρcore_R)
-                @test ρcore_R ≈ core_charge_density_real(psp)(R_rot)
             end
 
             K = rand(3) .+ eps(Float64)
             K_rot = rotate_vector(random_versor(), K)
 
-            @test local_potential_fourier(psp)(K) ≈ local_potential_fourier(psp)(K_rot)
-            for l in angular_momenta(psp), n in projector_radial_indices(psp, l)
-                @test projector_fourier(psp, l, n)(K) ≈ projector_fourier(psp, l, n)(K_rot)
+            for quantity in [BetaProjector(), ChiProjector()]
+                if has_quantity(quantity, psp)
+                    for l in angular_momenta(psp), n in 1:n_radials(quantity, psp, l)
+                        rmin = isa(psp, NumericPsP) ? first(psp.r) : 0
+                        rmax = cutoff_radius(quantity, psp, l, n)
+                        if !isnothing(rmax)
+                            R = rescale_vector(rand(3), rmin, rmax)
+                            R_rot = rotate_vector(random_versor(), R)
+
+                            @test psp_quantity_evaluator(RealSpace(), quantity, psp, l, n)(R) ≈
+                                psp_quantity_evaluator(RealSpace(), quantity, psp, l, n)(R_rot)
+                            @test psp_quantity_evaluator(FourierSpace(), quantity, psp, l, n)(K) ≈
+                                psp_quantity_evaluator(FourierSpace(), quantity, psp, l, n)(K_rot)
+                        end
+                    end
+                end
             end
-            for l in angular_momenta(psp), n in chi_function_radial_indices(psp, l)
-                @test chi_function_fourier(psp, l, n)(K) ≈
-                      chi_function_fourier(psp, l, n)(K_rot)
-            end
-            ρval_K = valence_charge_density_fourier(psp)(K)
-            @test typeof(ρval_K) <: Union{Nothing,Real}
-            if !isnothing(ρval_K)
-                @test ρval_K ≈ valence_charge_density_fourier(psp)(K_rot)
-            end
-            ρcore_K = core_charge_density_fourier(psp)(K)
-            @test typeof(ρcore_K) <: Union{Nothing,Real}
-            if !isnothing(ρcore_K)
-                @test ρcore_K ≈ core_charge_density_fourier(psp)(K_rot)
+
+            for quantity in [LocalPotential(), ValenceChargeDensity(), CoreChargeDensity()]
+                if has_quantity(quantity, psp)
+                    rmin = isa(psp, NumericPsP) ? first(psp.r) : 0
+                    rmax = cutoff_radius(quantity, psp)
+                    if !isnothing(rmax)
+                        R = rescale_vector(rand(3), rmin, rmax)
+                        R_rot = rotate_vector(random_versor(), R)
+                        @test psp_quantity_evaluator(RealSpace(), quantity, psp)(R) ≈
+                            psp_quantity_evaluator(RealSpace(), quantity, psp)(R_rot)
+                        @test psp_quantity_evaluator(FourierSpace(), quantity, psp)(K) ≈
+                            psp_quantity_evaluator(FourierSpace(), quantity, psp)(K_rot)
+                    end
+                end
             end
 
             @test relativistic_treatment(psp) in (:scalar, :full)

--- a/test/psp/upf_hgh.jl
+++ b/test/psp/upf_hgh.jl
@@ -6,8 +6,8 @@
 
         @testset "Local potential agrees in Fourier space" begin
             for q in (0.01, 0.5, 2.5, 5.0, 10.0)
-                @test local_potential_fourier(upf2)(q) ≈
-                      local_potential_fourier(hgh)(q) rtol = 1e-5 atol = 1e-5
+                @test psp_quantity_evaluator(FourierSpace(), LocalPotential(), upf2)(q) ≈
+                      psp_quantity_evaluator(FourierSpace(), LocalPotential(), hgh)(q) rtol = 1e-5 atol = 1e-5
             end
         end
 
@@ -15,10 +15,10 @@
             lmax = min(max_angular_momentum(upf2), max_angular_momentum(hgh))
             @testset for q in (0.0, 0.01, 0.5, 2.5, 5.0, 10.0)
                 for l in 0:lmax
-                    nmax = min(n_projector_radials(upf2, l), n_projector_radials(hgh, l))
+                    nmax = min(n_radials(BetaProjector(), upf2, l), n_radials(BetaProjector(), hgh, l))
                     for n in 1:nmax
-                        @test projector_fourier(upf2, l, n)(q) ≈
-                              projector_fourier(hgh, l, n)(q) atol = 1e-6 rtol = 1e-6
+                        @test psp_quantity_evaluator(FourierSpace(), BetaProjector(), upf2, l, n)(q) ≈
+                              psp_quantity_evaluator(FourierSpace(), BetaProjector(), hgh, l, n)(q) atol = 1e-6 rtol = 1e-6
                     end
                 end
             end
@@ -27,17 +27,17 @@
         @testset "Projector coupling coefficients agree" begin
             lmax = min(max_angular_momentum(upf2), max_angular_momentum(hgh))
             for l in 0:lmax
-                nmax = min(n_projector_radials(upf2, l), n_projector_radials(hgh, l))
+                nmax = min(n_radials(BetaProjector(), upf2, l), n_radials(BetaProjector(), hgh, l))
                 for n in 1:nmax, m in n:nmax
-                    @test projector_coupling(upf2, l, n, m) ≈
-                          projector_coupling(hgh, l, n, m) atol = 1e-8 rtol = 1e-8
+                    @test get_quantity(BetaCoupling(), upf2, l, n, m) ≈
+                          get_quantity(BetaCoupling(), hgh, l, n, m) atol = 1e-8 rtol = 1e-8
                 end
             end
         end
 
         @testset "Pseudo energy correction agrees" begin
-            @test pseudo_energy_correction(Float64, upf2) ≈
-                  pseudo_energy_correction(Float64, hgh) rtol = 1e-5 atol = 1e-5
+            @test psp_energy_correction(Float64, upf2) ≈
+                  psp_energy_correction(Float64, hgh) rtol = 1e-5 atol = 1e-5
         end
     end
 end

--- a/test/psp/upf_psp8.jl
+++ b/test/psp/upf_psp8.jl
@@ -6,8 +6,8 @@
 
         @testset "Local potential agrees in Fourier space" begin
             for q in (0.01, 0.5, 2.5, 5.0, 10.0)
-                @test local_potential_fourier(upf2)(q) ≈
-                      local_potential_fourier(psp8)(q) rtol = 1e-3 atol = 1e-3
+                @test psp_quantity_evaluator(FourierSpace(), LocalPotential(), upf2)(q) ≈
+                      psp_quantity_evaluator(FourierSpace(), LocalPotential(), psp8)(q) rtol = 1e-3 atol = 1e-3
             end
         end
 
@@ -20,15 +20,15 @@
             end
             if !isnothing(upf2.ρcore) & !isnothing(psp8.ρcore)
                 for q in (0.01, 0.5, 2.5, 5.0, 10.0)
-                    @test local_potential_fourier(upf2)(q) ≈
-                          local_potential_fourier(psp8)(q) rtol = 1e-3 atol = 1e-3
+                    @test psp_quantity_evaluator(FourierSpace(), CoreChargeDensity(), upf2)(q) ≈
+                          psp_quantity_evaluator(FourierSpace(), CoreChargeDensity(), psp8)(q) rtol = 1e-3 atol = 1e-3
                 end
             end
         end
 
         @testset "Pseudo energy correction agrees" begin
-            @test pseudo_energy_correction(Float64, upf2) ≈
-                  pseudo_energy_correction(Float64, psp8) rtol = 1e-2 atol = 1e-2
+            @test psp_energy_correction(Float64, upf2) ≈
+                  psp_energy_correction(Float64, psp8) rtol = 1e-2 atol = 1e-2
         end
     end
 end


### PR DESCRIPTION
While working to integrate PseudoPotentialIO into DFTK, there were a few points where having a dispatch flag-based interface in PPIO would help to reduce code duplication, namely

1. When calculating atomic form-factors for constructing a density superposition, the code is identical except for the function used to calculate the Fourier transform of the atomic density quantity. This affects density guesses and non-linear core-correction.
2. When building atomic orbital-like projection vectors for the non-local potential term, wavefunction guesses, DFT+U, and projected quantities

Here, I define a set of `AbstractPsPQuantity` structs which are used to select dispatches for a variety of functions:
```julia
has_quantity(::AbstractPsPQuantity, ::AbstractPsP)
get_quantity(::AbstractPsPQuantity, ::AbstractPsP)
cutoff_radius(::AbstractPsPQuantity, ::AbstractPsP)
n_radials(::AbstractPsPQuantity, ::AbstractPsP)
n_angulars(::AbstractPsPQuantity, ::AbstractPsP)
psp_quantity_evaluator(::EvaluationSpace, ::AbstractPsPQuantity, ::AbstractPsP)
```

This significantly reduces code duplication in PPIO and should allow for additional quantities to be added without much effort.